### PR TITLE
Missing the "_" character in the prefix GCRY_MD_FLAG in Hash class.

### DIFF
--- a/gcrypt.vapi
+++ b/gcrypt.vapi
@@ -502,7 +502,7 @@ namespace GCrypt {
 
 	[CCode (lower_case_cname = "cipher_")]
 	namespace Cipher {
-		[CCode (cname = "enum gcry_cipher_algos", cprefix = "GCRY_CIPHER_", free_function = "gcry_cipher_close")]
+		[CCode (cname = "enum gcry_cipher_algos", cprefix = "GCRY_CIPHER_")]
 		public enum Algorithm {
 			NONE,
 			IDEA,
@@ -560,7 +560,7 @@ namespace GCrypt {
 			CBC_MAC   /* Enable CBC message auth. code (MAC). */
 		}
 		[Compact]
-		[CCode (cname = "gcry_cipher_hd_t", lower_case_cprefix = "gcry_cipher_")]
+		[CCode (cname = "gcry_cipher_hd_t", lower_case_cprefix = "gcry_cipher_", free_function = "gcry_cipher_close")]
 		public class Cipher {
 			public static Error open (out Cipher cipher, Algorithm algo, Mode mode, Flag flags);
 			public void close ();

--- a/gcrypt.vapi
+++ b/gcrypt.vapi
@@ -502,7 +502,7 @@ namespace GCrypt {
 
 	[CCode (lower_case_cname = "cipher_")]
 	namespace Cipher {
-		[CCode (cname = "enum gcry_cipher_algos", cprefix = "GCRY_CIPHER_")]
+		[CCode (cname = "enum gcry_cipher_algos", cprefix = "GCRY_CIPHER_", free_function = "gcry_cipher_close")]
 		public enum Algorithm {
 			NONE,
 			IDEA,

--- a/gcrypt.vapi
+++ b/gcrypt.vapi
@@ -619,10 +619,12 @@ namespace GCrypt {
 			public Error get_oid (uchar[] buffer);
 		}
 
-		[CCode (cname = "enum gcry_md_flags", cprefix = "GCRY_MD_FLAG")]
+		[CCode (cname = "enum gcry_md_flags", cprefix = "GCRY_MD_FLAG_")]
 		public enum Flag {
 			SECURE,
-			HMAC
+			HMAC,
+            /* Introduced in version 1.6.0 to fix a bug in the Whirlpool code */
+            BUGEMU1
 		}
 
 		public static Error open (out Hash hash, Algorithm algo, Flag flag);


### PR DESCRIPTION
Added also a new flag available in the version 1.6.0 to fix a bug in the Whirlpool code which led to a wrong result for certain input sizes and write patterns.