### PR TITLE
Add PBKDF1 to GCrypt.KeyDerivation.Algorithm

### DIFF
--- a/gcrypt.vapi
+++ b/gcrypt.vapi
@@ -819,6 +819,7 @@ namespace GCrypt {
 			SIMPLE_S2K,
 			SALTED_S2K,
 			ITERSALTED_S2K,
+			PBKDF1,
 			PBKDF2,
 			SCRYPT
 		}


### PR DESCRIPTION
PBKDF1 is omitted in menual (https://www.gnu.org/software/libgcrypt/) but exists in header file (src/gcrypt.h.in)